### PR TITLE
Spelling error

### DIFF
--- a/index.html
+++ b/index.html
@@ -4244,7 +4244,7 @@
         </tr>
         <tr>
           <td>
-            Teneriffe
+            Tenerife
           </td>
           <td>
             8,500


### PR DESCRIPTION
Assuming Teneriffe is referring to the spanish island.

Source: https://en.wikipedia.org/wiki/Teneriffe
